### PR TITLE
Fix charbounds and centered text issues

### DIFF
--- a/src/RA8876_t3.cpp
+++ b/src/RA8876_t3.cpp
@@ -5671,7 +5671,7 @@ void RA8876_t3::charBounds(char c, int16_t *x, int16_t *y,
 	            *x  = 0; // Reset x to zero, advance y by one line
 	            *y += font->line_space;
 	            x1 = *x + xoffset,
-	            y1 = *y + yoffset,
+	            y1 = *y + font->cap_height - height - yoffset,
 	            x2 = x1 + width,
 	            y2 = y1 + height;
         	}
@@ -6305,16 +6305,16 @@ size_t RA8876_t3::write(const uint8_t *buffer, size_t size) {
 	  	// Note we may want to play with the x ane y returned if they offset some
 		if (_absoluteCenter && strngWidth > 0){//Avoid operations for strngWidth = 0
 			_absoluteCenter = false;
-			_cursorX = _cursorX - ((x + strngWidth) / 2);
-			_cursorY = _cursorY - ((y + strngHeight) / 2);
+			_cursorX = _cursorX - (x + strngWidth / 2);
+			_cursorY = _cursorY - (y + strngHeight / 2);
 		} else if (_relativeCenter && strngWidth > 0){//Avoid operations for strngWidth = 0
 			_relativeCenter = false;
 			if (bitRead(_TXTparameters,5)) {//X = center
-				_cursorX = (_width / 2) - ((x + strngWidth) / 2);
+				_cursorX = (_width / 2) - (x + strngWidth / 2);
 				_TXTparameters &= ~(1 << 5);//reset
 			}
 			if (bitRead(_TXTparameters,6)) {//Y = center
-				_cursorY = (_height / 2) - ((y + strngHeight) / 2) ;
+				_cursorY = (_height / 2) - (y + strngHeight / 2) ;
 				_TXTparameters &= ~(1 << 6);//reset
 			}
 		}


### PR DESCRIPTION
This is a similar fix that resulted from @KurtE's changes to the ILI9431_t3n library: 
```
The charbounds code did not take the caps height font value into account for giving you the correct positions when for example simply asking for the
bounds for "-"

Also then the centering code did not properly handle the X and/or Y offsets, it like the width put it into the / 2, where it should be the whole value.
```