### PR TITLE
Update RA8876_t3.cpp

### DIFF
--- a/src/RA8876_t3.cpp
+++ b/src/RA8876_t3.cpp
@@ -3219,7 +3219,7 @@ void RA8876_t3::bteMpuWriteColorExpansionData(ru32 des_addr,ru16 des_image_width
   
   for(i=0;i< height;i++)
   {	
-    for(j=0;j< (width/8);j++)
+    for(j=0;j< ((width+7)/8);j++)
     {
       lcdDataWrite(*data, false);
       data++;
@@ -3266,7 +3266,7 @@ void RA8876_t3::bteMpuWriteColorExpansionWithChromaKeyData(ru32 des_addr,ru16 de
   
   for(i=0;i< height;i++)
   {	
-    for(j=0;j< (width/8);j++)
+    for(j=0;j< ((width+7)/8);j++)
     {
       lcdDataWrite(*data, false);
       data++;


### PR DESCRIPTION
bteMpuWriteColorExpansionData() and bteMpuWriteColorExpansionWithChromaKeyData() do not currently correctly handle the case where the width is not an exact multiple of 8. This change rounds up the width to the nearest exact byte boundary to ensure that the gpu gets enough data to process the command. If the width is an exact multiple of 8 then this code will behave exactly as before.