### PR TITLE
Remove code that resets the Flexio on every read/write...

### DIFF
--- a/RA8876_t41_p/src/RA8876_t41_p.h
+++ b/RA8876_t41_p/src/RA8876_t41_p.h
@@ -191,6 +191,13 @@ class RA8876_t41_p : public RA8876_common {
     void FlexIO_Config_SnglBeat();
     void FlexIO_Config_MultiBeat();
     void FlexIO_Config_SnglBeat_Read();
+    typedef enum { CONFIG_CLEAR = 0,
+                   CONFIG_SNGLBEAT,
+                   CONFIG_MULTIBEAT,
+                   CONFIG_SNGLREAD } Flexio_config_state_t;
+    Flexio_config_state_t flex_config = CONFIG_CLEAR;
+
+    
 
     void microSecondDelay();
 


### PR DESCRIPTION
That is I commented out all of the:
p->CTRL |= FLEXIO_CTRL_SWRST;
Lines, so it does not consistently reset the Flexio object. So other objects might work on same flexio...

Code in place also, that if I am already in that mode don't need to do anything.

Updated the read and write single... to clear out the others settings.

So far it appears to work.

Added Debug code under #ifdef DEBUG and the like.
Turned off...  also DEBUG_FLEXIO, which has a function to print out flexio configuration, like:
**********************************
```
FlexIO(0x20006504) Index: 1 - FlexIO_Config_SnglBeat_Read
CCM_CDCDR: 33f71f92
CCM FlexIO1: 0 FlexIO2: 3 FlexIO3: 3000
VERID:1010001 PARAM:2200808 CTRL:0 PIN: 30ff0
SHIFTSTAT:0 SHIFTERR=0 TIMSTAT=0
SHIFTSIEN:0 SHIFTEIEN=0 TIMIEN=0
SHIFTSDEN:0 SHIFTSTATE=0
SHIFTCTL: 00000000 00000000 00000000 00810401 00000000 00000000 00000000 00000000
SHIFTCFG: 00000000 00000000 00000000 00070000 00000000 00000000 00000000 00000000
TIMCTL:dc31081 0 0 0
TIMCFG:2210 0 0 0
TIMCMP:11d 0 0 0
`````