### PR TITLE
Cherry pick - From WIP - BUS_WIDTH - Was getting confusing plus start of ability to set the FlexIO pins.

### DIFF
--- a/RA8876_GFX/src/RA8876_common.cpp
+++ b/RA8876_GFX/src/RA8876_common.cpp
@@ -132,14 +132,14 @@ int16_t SCREEN_HEIGHT = VDH;
 void RA8876_common::RA8876_GFX(uint16_t buswidth) {
     _width = SCREEN_WIDTH;
     _height = SCREEN_HEIGHT;
-    BUS_WIDTH = buswidth;
+    _bus_width = buswidth;
 }
 
 void RA8876_common::setBusWidth(uint16_t buswidth) {
     if (buswidth == 8 || buswidth == 16) {
-        BUS_WIDTH = buswidth;
+        _bus_width = buswidth;
     } else {
-        BUS_WIDTH = 8; // defaults to 8
+        _bus_width = 8; // defaults to 8
         Serial.println("BUSWIDTH NOT SUPPORTED!!!! Defaut used");
     }
 }
@@ -164,7 +164,7 @@ boolean RA8876_common::ra8876Initialize() {
     lcdDataWrite(RA8876_PLL_ENABLE << 7 | RA8876_WAIT_NO_MASK << 6 | RA8876_KEY_SCAN_DISABLE << 5 | RA8876_TFT_OUTPUT24 << 3 |
      RA8876_I2C_MASTER_DISABLE << 2 | RA8876_SERIAL_IF_ENABLE << 1 | RA8876_HOST_DATA_BUS_SERIAL);
 #else
-	if(BUS_WIDTH == 16) {
+	if(_bus_width == 16) {
 		lcdDataWrite(RA8876_PLL_ENABLE<<7|RA8876_WAIT_NO_MASK<<6|RA8876_KEY_SCAN_DISABLE<<5|RA8876_TFT_OUTPUT24<<3
 		|RA8876_I2C_MASTER_DISABLE<<2|RA8876_SERIAL_IF_ENABLE<<1|RA8876_HOST_DATA_BUS_16BIT);
 	} else {
@@ -4277,7 +4277,7 @@ void RA8876_common::writeRectImpl(int16_t x, int16_t y, int16_t w, int16_t h, co
 		case 0: // we will just hand off for now to 
 				// unrolled to bte call
 				//Using the BTE function is faster and will use DMA if available
-                if(BUS_WIDTH == 8) {
+                if(_bus_width == 8) {
 			    bteMpuWriteWithROPData8(currentPage, width(), start_x, start_y,  //Source 1 is ignored for ROP 12
                               currentPage, width(), start_x, start_y, w, h,     //destination address, pagewidth, x/y, width/height
                               RA8876_BTE_ROP_CODE_12,
@@ -4293,7 +4293,7 @@ void RA8876_common::writeRectImpl(int16_t x, int16_t y, int16_t w, int16_t h, co
 			{
 				while (h) {
 					//Serial.printf("DP %x, %d, %d %d\n", rotated_row, h, start_x, y);
-                if(BUS_WIDTH == 8) {
+                if(_bus_width == 8) {
 				    bteMpuWriteWithROPData8(currentPage, height(), start_y, start_x,  //Source 1 is ignored for ROP 12
 	                              currentPage, height(),  start_y, start_x, 1, w,     //destination address, pagewidth, x/y, width/height
 	                              RA8876_BTE_ROP_CODE_12,
@@ -4322,7 +4322,7 @@ void RA8876_common::writeRectImpl(int16_t x, int16_t y, int16_t w, int16_t h, co
 				// lets reverse data per row...
 				while (h) {
 					for (int i = 0; i < w; i++) rotated_buffer[w-i-1] = *pcolors++;
-                if(BUS_WIDTH == 8) {
+                if(_bus_width == 8) {
 				    bteMpuWriteWithROPData8(currentPage, width(), start_x, start_y,  //Source 1 is ignored for ROP 12
                               currentPage, width(), (width()- w) - start_x , start_y, w, 1,     //destination address, pagewidth, x/y, width/height
                               RA8876_BTE_ROP_CODE_12,
@@ -4351,7 +4351,7 @@ void RA8876_common::writeRectImpl(int16_t x, int16_t y, int16_t w, int16_t h, co
 			    start_y += h;
 				while (h) {
 					//Serial.printf("DP %x, %d, %d %d\n", rotated_row, h, start_x, y);
-                if(BUS_WIDTH == 8) {
+                if(_bus_width == 8) {
 				    bteMpuWriteWithROPData8(currentPage, height(), start_y, start_x,  //Source 1 is ignored for ROP 12
 	                              currentPage, height(), height() - start_y, start_x, 1, w,     //destination address, pagewidth, x/y, width/height
 	                              RA8876_BTE_ROP_CODE_12,
@@ -4427,7 +4427,7 @@ void RA8876_common::writeRotatedRect(int16_t x, int16_t y, int16_t w, int16_t h,
     switch (_rotation) {
     case 0:
         // Same as normal writeRect
-        if (BUS_WIDTH == 8) {
+        if (_bus_width == 8) {
             bteMpuWriteWithROPData8(currentPage, width(), start_x, start_y,       // Source 1 is ignored for ROP 12
                                     currentPage, width(), start_x, start_y, w, h, // destination address, pagewidth, x/y, width/height
                                     RA8876_BTE_ROP_CODE_12,
@@ -4441,7 +4441,7 @@ void RA8876_common::writeRotatedRect(int16_t x, int16_t y, int16_t w, int16_t h,
         break;
     case 2:
         // Same as normal writeRect
-        if (BUS_WIDTH == 8) {
+        if (_bus_width == 8) {
             bteMpuWriteWithROPData8(currentPage, width(), start_x, start_y,                       // Source 1 is ignored for ROP 12
                                     currentPage, width(), (width() - w) - start_x, start_y, w, h, // destination address, pagewidth, x/y, width/height
                                     RA8876_BTE_ROP_CODE_12,
@@ -4454,7 +4454,7 @@ void RA8876_common::writeRotatedRect(int16_t x, int16_t y, int16_t w, int16_t h,
         }
         break;
     case 1:
-        if (BUS_WIDTH == 8) {
+        if (_bus_width == 8) {
             bteMpuWriteWithROPData8(currentPage, height(), start_y, start_x,       // Source 1 is ignored for ROP 12
                                     currentPage, height(), start_y, start_x, h, w, // destination address, pagewidth, x/y, width/height
                                     RA8876_BTE_ROP_CODE_12,
@@ -4467,7 +4467,7 @@ void RA8876_common::writeRotatedRect(int16_t x, int16_t y, int16_t w, int16_t h,
         }
         break;
     case 3:
-        if (BUS_WIDTH == 8) {
+        if (_bus_width == 8) {
             bteMpuWriteWithROPData8(currentPage, height(), start_y, start_x,                        // Source 1 is ignored for ROP 12
                                     currentPage, height(), (height() - h) - start_y, start_x, h, w, // destination address, pagewidth, x/y, width/height
                                     RA8876_BTE_ROP_CODE_12,

--- a/RA8876_GFX/src/RA8876_common.h
+++ b/RA8876_GFX/src/RA8876_common.h
@@ -173,6 +173,7 @@ class RA8876_common : public Print {
     /*****************************************************/
     void RA8876_GFX(uint16_t buswidth);
     void setBusWidth(uint16_t buswidth);
+    uint8_t getBusWidth() {return _bus_width;}
 
     /*  Picture Functions */
     void putPicture_16bpp(ru16 x, ru16 y, ru16 width, ru16 height) {};                                   // not recommended: use BTE instead
@@ -733,8 +734,7 @@ class RA8876_common : public Print {
   protected:
     int16_t _width, _height;
     uint8_t _rotation;
-    uint16_t BUS_WIDTH;
-
+    uint8_t _bus_width;
   private:
     //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     //    RA8876 Parameters

--- a/RA8876_t41_p/examples/MemoryTransfer/MemoryTransfer.ino
+++ b/RA8876_t41_p/examples/MemoryTransfer/MemoryTransfer.ino
@@ -75,7 +75,7 @@ void writeImage(int x, int y, int w, int h, const unsigned char *image) {
   //This code is identical to what's inside tft.putPicture()
   
   //Sending bytes individually, in normal byte order
-  if(BUS_WIDTH == 8) {
+  if(tft.getBusWidth() == 8) {
     tft.bteMpuWriteWithROPData8(tft.currentPage, tft.width(), x, y,  //Source 1 is ignored for now
                                 tft.currentPage, tft.width(), x, y, w, h,     //destination address, pagewidth, x/y, width/height
                                 RA8876_BTE_ROP_CODE_12,
@@ -94,7 +94,7 @@ void writeImage16(int x, int y, int w, int h, const unsigned char *image) {
   //Cast the data array pointer to insist that it contains 16-bit unsigned integers
   //The only benefit of this is if you already had your data in byte-reversed 16-bit form.
   //It's actually slower than the 8 bit version.
-  if(BUS_WIDTH == 16) {
+  if(tft.getBusWidth() == 16) {
     tft.bteMpuWriteWithROPData16(tft.currentPage, tft.width(), x, y,  //Source 1 is ignored for now
                                  tft.currentPage, tft.width(), x, y, w, h,     //destination address, pagewidth, x/y, width/height
                                  RA8876_BTE_ROP_CODE_12,
@@ -109,7 +109,7 @@ void writeImage16(int x, int y, int w, int h, const unsigned char *image) {
 
 void writeImageChromakey(int x, int y, int w, int h, ru16 chromakeyColor, const unsigned char *image) {
   //copy from the PROGMEM array to the screen, at the specified x/y location with one color transparent
-  if(BUS_WIDTH == 16) {
+  if(tft.getBusWidth() == 16) {
     tft.bteMpuWriteWithChromaKeyData16(//no source 1 for this operation
       tft.currentPage, tft.width(), x, y, w, h,     //destination address, x/y, width/height
       chromakeyColor,
@@ -233,7 +233,7 @@ void setup() {
   Serial.print((float)(end2Time - endTime) / 1000.0, 3);
   Serial.println("us because data transfer was still underway");
 
-  if(BUS_WIDTH == 16) {
+  if(tft.getBusWidth() == 16) {
     startTime = micros();
     writeImage16(20, 5, IMG_WIDTH, IMG_HEIGHT, image_565);  //basic send, using 16-bit byte-swapped data
     endTime = micros();

--- a/RA8876_t41_p/examples/TestCases/Kurts_RA8876_p_FB_and_clip_tests/Kurts_RA8876_p_FB_and_clip_tests.ino
+++ b/RA8876_t41_p/examples/TestCases/Kurts_RA8876_p_FB_and_clip_tests/Kurts_RA8876_p_FB_and_clip_tests.ino
@@ -104,9 +104,11 @@ void setup() {
 
 #if defined(use_spi)
     tft.begin();
+    tft.setBusWidth(8);
 #else
     tft.begin(20);
 #endif
+
     //  tft.setFrameBuffer(tft_frame_buffer);
     tft.backlight(true);
 
@@ -458,15 +460,14 @@ void drawTestScreen() {
 #define BAND_HEIGHT 20
 #define BAND_START_X 200
 #define BAND_START_Y 259
-
-    tft.fillRect(BAND_START_X + BAND_WIDTH * 0, BAND_START_Y, BAND_WIDTH, BAND_HEIGHT, RED);
-    tft.fillRect(BAND_START_X + BAND_WIDTH * 1, BAND_START_Y, BAND_WIDTH, BAND_HEIGHT, GREEN);
-    tft.fillRect(BAND_START_X + BAND_WIDTH * 2, BAND_START_Y, BAND_WIDTH, BAND_HEIGHT, BLUE);
-    tft.fillRect(BAND_START_X + BAND_WIDTH * 3, BAND_START_Y, BAND_WIDTH, BAND_HEIGHT, BLACK);
-    tft.fillRect(BAND_START_X + BAND_WIDTH * 4, BAND_START_Y, BAND_WIDTH, BAND_HEIGHT, WHITE);
-    tft.fillRect(BAND_START_X + BAND_WIDTH * 5, BAND_START_Y, BAND_WIDTH, BAND_HEIGHT, YELLOW);
-    tft.fillRect(BAND_START_X + BAND_WIDTH * 6, BAND_START_Y, BAND_WIDTH, BAND_HEIGHT, CYAN);
-    tft.fillRect(BAND_START_X + BAND_WIDTH * 7, BAND_START_Y, BAND_WIDTH, BAND_HEIGHT, PINK);
+    uint16_t band_colors[] = { RED, GREEN, PINK, DARKGREY, WHITE, YELLOW, CYAN, BLUE };
+#define COUNT_BANDS (sizeof(band_colors) / sizeof(band_colors[0]))
+    Serial.println("Band colors: ");
+    for (uint8_t i = 0; i < COUNT_BANDS; i++) {
+        tft.fillRect(BAND_START_X + BAND_WIDTH * i, BAND_START_Y, BAND_WIDTH, BAND_HEIGHT, band_colors[i]);
+        Serial.printf(" %x",  band_colors[i]);
+    }
+    Serial.println();
     memset(pixel_data, 0, sizeof(pixel_data));
     tft.readRect(BAND_START_X, BAND_START_Y, BAND_WIDTH * 8, BAND_HEIGHT, pixel_data);
     Serial.printf("%04X %04X %04X %04X %04X %04X %04X %04X\n",
@@ -523,6 +524,15 @@ void drawTestScreen() {
     memset(pb + MEMSET_CNT * 2, 2, MEMSET_CNT);
     memset(pb + MEMSET_CNT * 3, 3, MEMSET_CNT);
     tft.writeRect8BPP(100, 400, 100, (4 * MEMSET_CNT) / 100, pb, palette);
+
+
+    tft.writeRect8BPP(250, 400, 40, 25,  pb, palette);
+
+
+    for (int i = 0; i < 1000; i++) pixel_data[i] = BLUE;
+    tft.writeRect(400, 400, 40, 25,  pixel_data);
+
+
 
 
     tft.writeRect1BPP(75, 100, 16, 16, pict1bpp, palette);

--- a/RA8876_t41_p/src/RA8876_t41_p.cpp
+++ b/RA8876_t41_p/src/RA8876_t41_p.cpp
@@ -198,19 +198,19 @@ FASTRUN void RA8876_t41_p::microSecondDelay() {
 }
 
 FASTRUN void RA8876_t41_p::gpioWrite() {
-#ifndef READS_USE_DIGITAL_WRITE
     pFlex->setIOPinToFlexMode(_wr_pin);
+#ifndef READS_USE_DIGITAL_WRITE
     pinMode(_rd_pin, OUTPUT);
-    digitalWriteFast(_rd_pin, HIGH);
 #endif    
+    digitalWriteFast(_rd_pin, HIGH);
 }
 
 FASTRUN void RA8876_t41_p::gpioRead() {
 #ifndef READS_USE_DIGITAL_WRITE
     pFlex->setIOPinToFlexMode(_rd_pin);
+#endif    
     pinMode(_wr_pin, OUTPUT);
     digitalWriteFast(_wr_pin, HIGH);
-#endif    
 }
 
 // If used this must be called before begin
@@ -449,12 +449,12 @@ FASTRUN void RA8876_t41_p::FlexIO_Config_SnglBeat_Read() {
 
     /* Configure the timer for shift clock */
 #ifndef RA8876_CLOCK_READ
-#define RA8876_CLOCK_READ
+#define RA8876_CLOCK_READ 60
 #endif    
+
     p->TIMCMP[0] =
         (((1 * 2) - 1) << 8) /* TIMCMP[15:8] = number of beats x 2 – 1 */
         | ((RA8876_CLOCK_READ / 2) - 1);    /* TIMCMP[7:0] = baud rate divider / 2 – 1 */
-
     p->TIMCFG[0] =
         FLEXIO_TIMCFG_TIMOUT(0)       /* Timer output logic one when enabled and not affected by reset */
         | FLEXIO_TIMCFG_TIMDEC(0)     /* Timer decrement on FlexIO clock, shift clock equals timer output */

--- a/RA8876_t41_p/src/RA8876_t41_p.cpp
+++ b/RA8876_t41_p/src/RA8876_t41_p.cpp
@@ -4,13 +4,13 @@
 /*
  * Ra8876LiteTeensy.cpp
  * Modified Version of: File Name : RA8876_t41_p.cpp
- *			Author    : RAiO Application Team
- *			Edit Date : 09/13/2017
- *			Version   : v2.0  1.modify bte_DestinationMemoryStartAddr bug
- *                 			  2.modify ra8876SdramInitial Auto_Refresh
- *                 			  3.modify ra8876PllInitial
+ *          Author    : RAiO Application Team
+ *          Edit Date : 09/13/2017
+ *          Version   : v2.0  1.modify bte_DestinationMemoryStartAddr bug
+ *                            2.modify ra8876SdramInitial Auto_Refresh
+ *                            3.modify ra8876PllInitial
  ****************************************************************
- * 	  	              : New 8080 Parallel version
+ *                    : New 8080 Parallel version
  *                    : For MicroMod
  *                    : By Warren Watson
  *                    : 06/07/2018 - 05/03/2024
@@ -83,13 +83,16 @@ void inline VDBGPrintf(...){};
 //**************************************************************//
 // Create RA8876 driver instance 8080 IF
 //**************************************************************//
+#ifndef BUS_WIDTH
+#define BUS_WIDTH 8
+#endif
 RA8876_t41_p::RA8876_t41_p(const uint8_t DCp, const uint8_t CSp, const uint8_t RSTp) 
     : _dc(DCp), _cs(CSp), _rst(RSTp),
       _data_pins{DISPLAY_D0, DISPLAY_D1, DISPLAY_D2, DISPLAY_D3, DISPLAY_D4, DISPLAY_D5, DISPLAY_D6, DISPLAY_D7,
 #if defined(DISPLAY_D8)
-      DISPLAY_D8, DISPLAY_D9, DISPLAY_D10, DISPLAY_D11, DISPLAY_D12, DISPLAY_D13, DISPLAY_D14, DISPLAY_D15}, _bus_width(BUS_WIDTH),
+      DISPLAY_D8, DISPLAY_D9, DISPLAY_D10, DISPLAY_D11, DISPLAY_D12, DISPLAY_D13, DISPLAY_D14, DISPLAY_D15}, 
 #else
-      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, _bus_width(8),
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 #endif      
       _wr_pin(DISPLAY_WR), _rd_pin(DISPLAY_RD) 
 {
@@ -155,7 +158,7 @@ FLASHMEM boolean RA8876_t41_p::begin(uint8_t baud_div) {
         return false;
 
     // read ID code must disable pll, 01h bit7 set 0
-    if (BUS_WIDTH == 16) {
+    if (_bus_width == 16) {
         lcdRegDataWrite(0x01, 0x09);
     } else {
         lcdRegDataWrite(0x01, 0x08);
@@ -209,6 +212,96 @@ FASTRUN void RA8876_t41_p::gpioRead() {
     digitalWriteFast(_wr_pin, HIGH);
 #endif    
 }
+
+// If used this must be called before begin
+// Set the FlexIO pins.  The first version you can specify just the wr, and read and optionsl first Data.
+// it will use information in the Flexio library to fill in d1-d7
+FASTRUN bool RA8876_t41_p::setFlexIOPins(uint8_t write_pin, uint8_t rd_pin, uint8_t tft_d0) {
+    DBGPrintf("RA8876_t41_p::setFlexIOPins(%u, %u, %u) %u %u %u\n", write_pin, rd_pin, tft_d0, _data_pins[0], _wr_pin, _rd_pin);
+    DBGFlush();
+    if (tft_d0 != 0xff) {
+#ifdef FLEX_IO_HAS_FULL_PIN_MAPPING
+        DBGPrintf("\td0 != 0xff\n\n");
+
+        uint8_t flexio_pin;
+        pFlex = FlexIOHandler::mapIOPinToFlexIOHandler(tft_d0, flexio_pin);
+        if ((pFlex == nullptr) || (flexio_pin == 0xff))
+            return false;
+
+        uint8_t flexio_wr = pFlex->mapIOPinToFlexPin(write_pin);
+        if (flexio_wr == 0xff) {
+            // WR pin not valid on pFlex, see if maybe 2 versus 3 issue...
+            pFlex = FlexIOHandler::mapIOPinToFlexIOHandler(write_pin, flexio_wr);
+            if (pFlex == nullptr) {
+                Serial.printf("RA8876_t41_p::FlexIO_Init() wr:%u is not valid flexio pin\n", write_pin);
+                return false;            
+            }
+            flexio_pin = pFlex->mapIOPinToFlexPin(tft_d0);
+            if (flexio_pin == 0xff) {
+                Serial.printf("RA8876_t41_p::FlexIO_Init() D0:%u and WR:%u are not on same flexio object", tft_d0, write_pin);
+            }
+        }
+        _data_pins[0] = tft_d0;
+
+
+        // lets dos some quick validation of the pins.
+        for (uint8_t i = 1; i < _bus_width; i++) {
+            flexio_pin++; // lets look up the what pins come next.
+            _data_pins[i] = pFlex->mapFlexPinToIOPin(flexio_pin);
+            if (_data_pins[i] == 0xff) {
+                Serial.printf("Failed to find Teensy IO pin for Flexio pin %u\n", flexio_pin);
+                return false;
+            }
+        }
+#else
+        return false;
+#endif
+    }
+    // set the write and read pins and see if d0 is not 0xff set it and compute the others.
+    if (write_pin != 0xff)
+        _wr_pin = write_pin;
+    if (rd_pin != 0xff)
+        _rd_pin = rd_pin;
+
+    DBGPrintf("FlexIO pins: data: %u %u %u %u %u %u %u %u WR:%u RD:%u\n",
+              _data_pins[0], _data_pins[1], _data_pins[2], _data_pins[3], _data_pins[4], _data_pins[5], _data_pins[6], _data_pins[7],
+              _wr_pin, _rd_pin);
+    return true;
+}
+
+// Set the FlexIO pins.  Specify all of the pins for 8 bit mode. Must be called before begin
+FLASHMEM bool RA8876_t41_p::setFlexIOPins(uint8_t write_pin, uint8_t rd_pin, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+                                           uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7,
+                                            uint8_t d8, uint8_t d9, uint8_t d10, uint8_t d11,
+                                            uint8_t d12, uint8_t d13, uint8_t d14, uint8_t d15
+                                           ) {
+    _data_pins[0] = d0;
+    _data_pins[1] = d1;
+    _data_pins[2] = d2;
+    _data_pins[3] = d3;
+    _data_pins[4] = d4;
+    _data_pins[5] = d5;
+    _data_pins[6] = d6;
+    _data_pins[7] = d7;
+    _wr_pin = write_pin;
+    _rd_pin = rd_pin;
+
+    _data_pins[8] = d8;
+    _data_pins[9] = d9;
+    _data_pins[10] = d10;
+    _data_pins[11] = d11;
+    _data_pins[12] = d12;
+    _data_pins[13] = d13;
+    _data_pins[14] = d14;
+    _data_pins[15] = d15;
+    DBGPrintf("FlexIO pins: data: %u %u %u %u %u %u %u %u %u %u %u %u %u %u %u %u WR:%u RD:%u\n",
+              _data_pins[0], _data_pins[1], _data_pins[2], _data_pins[3], _data_pins[4], _data_pins[5], _data_pins[6], _data_pins[7],
+              _data_pins[8], _data_pins[9], _data_pins[10], _data_pins[11], _data_pins[12], _data_pins[13], _data_pins[14], _data_pins[15],
+              _wr_pin, _rd_pin);
+    // Note this does not verify the pins are valid.
+    return true;
+}
+
 
 
 FASTRUN void RA8876_t41_p::FlexIO_Init() {
@@ -344,7 +437,7 @@ FASTRUN void RA8876_t41_p::FlexIO_Config_SnglBeat_Read() {
     /* Configure the shifters */
         FLEXIO_SHIFTCFG_SSTOP(0)                 /* Shifter stop bit disabled */
         | FLEXIO_SHIFTCFG_SSTART(0)              /* Shifter start bit disabled and loading data on enabled */
-        | FLEXIO_SHIFTCFG_PWIDTH(BUS_WIDTH - 1); /* Bus width */
+        | FLEXIO_SHIFTCFG_PWIDTH(_bus_width - 1); /* Bus width */
 
     p->SHIFTCTL[3] =
         FLEXIO_SHIFTCTL_TIMSEL(0)      /* Shifter's assigned timer index */
@@ -421,7 +514,7 @@ FASTRUN void RA8876_t41_p::FlexIO_Config_SnglBeat() {
         FLEXIO_SHIFTCFG_INSRC * (1)              /* Shifter input */
         | FLEXIO_SHIFTCFG_SSTOP(0)               /* Shifter stop bit disabled */
         | FLEXIO_SHIFTCFG_SSTART(0)              /* Shifter start bit disabled and loading data on enabled */
-        | FLEXIO_SHIFTCFG_PWIDTH(BUS_WIDTH - 1); // Was 7 for 8 bit bus         /* Bus width */
+        | FLEXIO_SHIFTCFG_PWIDTH(_bus_width - 1); // Was 7 for 8 bit bus         /* Bus width */
 
     p->SHIFTCTL[0] =
         FLEXIO_SHIFTCTL_TIMSEL(0)      /* Shifter's assigned timer index */
@@ -512,7 +605,7 @@ FASTRUN void RA8876_t41_p::FlexIO_Config_MultiBeat() {
             FLEXIO_SHIFTCFG_INSRC * (1U)             /* Shifter input from next shifter's output */
             | FLEXIO_SHIFTCFG_SSTOP(0U)              /* Shifter stop bit disabled */
             | FLEXIO_SHIFTCFG_SSTART(0U)             /* Shifter start bit disabled and loading data on enabled */
-            | FLEXIO_SHIFTCFG_PWIDTH(BUS_WIDTH - 1); /* 8 bit shift width */
+            | FLEXIO_SHIFTCFG_PWIDTH(_bus_width - 1); /* 8 bit shift width */
     }
 
     p->SHIFTCTL[0] =
@@ -664,11 +757,11 @@ FASTRUN void RA8876_t41_p::_onCompleteCB() {
 // This is a simplified wrapper - more advanced uses (such as putting data onto a page other than current) 
 //   should use the underlying BTE functions.
 void RA8876_t41_p::putPicture(ru16 x, ru16 y, ru16 w, ru16 h, const unsigned char *data) {
-	//The putPicture_16bppData8 function in the base class is not ideal - it damages the activeWindow setting
-	//It also is harder to make it DMA.
-	//Ra8876_Lite::putPicture_16bppData8(x, y, w, h, data);
-	//Using the BTE function is faster and will use DMA if available
-  if(BUS_WIDTH == 16) {
+    //The putPicture_16bppData8 function in the base class is not ideal - it damages the activeWindow setting
+    //It also is harder to make it DMA.
+    //Ra8876_Lite::putPicture_16bppData8(x, y, w, h, data);
+    //Using the BTE function is faster and will use DMA if available
+  if(_bus_width == 16) {
     bteMpuWriteWithROPData16(currentPage, width(), x, y,  //Source 1 is ignored for ROP 12
                               currentPage, width(), x, y, w, h,     //destination address, pagewidth, x/y, width/height
                               RA8876_BTE_ROP_CODE_12,
@@ -695,7 +788,7 @@ FASTRUN void RA8876_t41_p::pushPixels16bitAsync(const uint16_t *pcolors, uint16_
 
 //**********************************************************************
 // This section defines the low level parallel 8080 access routines.
-// It uses "BUS_WIDTH" (8 or 16) to decide which drivers to use.
+// It uses "_bus_width" (8 or 16) to decide which drivers to use.
 //**********************************************************************
 void RA8876_t41_p::LCD_CmdWrite(unsigned char cmd) {
     //  startSend();
@@ -780,7 +873,7 @@ ru8 RA8876_t41_p::lcdDataRead(bool finalize) {
 
     // Set FlexIO back to Write mode
     FlexIO_Config_SnglBeat(); // Not sure if this is needed.
-    if (BUS_WIDTH == 8)
+    if (_bus_width == 8)
         return data;
     else
         return (data >> 8) & 0xff;
@@ -816,7 +909,7 @@ ru8 RA8876_t41_p::lcdStatusRead(bool finalize) {
     // Set FlexIO back to Write mode
     FlexIO_Config_SnglBeat();
 
-    if (BUS_WIDTH == 8)
+    if (_bus_width == 8)
         return data;
     else
         return (data >> 8) & 0xff;
@@ -845,7 +938,7 @@ ru8 RA8876_t41_p::lcdRegDataRead(ru8 reg, bool finalize) {
 //******************************************************************
 void RA8876_t41_p::lcdDataWrite16bbp(ru16 data, bool finalize) {
     //  while(digitalReadFast(WINT) == 0);  // If monitoring XnWAIT signal from RA8876.
-    if (BUS_WIDTH == 8) {
+    if (_bus_width == 8) {
         lcdDataWrite(data & 0xff);
         lcdDataWrite(data >> 8);
     } else {
@@ -866,7 +959,7 @@ void RA8876_t41_p::lcdDataWrite16(uint16_t data, bool finalize) {
     CSLow();
     DCHigh();
 
-    if (BUS_WIDTH == 16) {
+    if (_bus_width == 16) {
         p->SHIFTBUF[0] = data;
         while (0 == (p->SHIFTSTAT & (1 << 0))) {
         }
@@ -1144,7 +1237,7 @@ void RA8876_t41_p::write16BitColor(uint16_t color) {
     if (_rotation & 1)
         delayNanoseconds(20);
 
-    if (BUS_WIDTH == 8) {
+    if (_bus_width == 8) {
         while (0 == (p->SHIFTSTAT & (1 << 0))) {
         }
         p->SHIFTBUF[0] = color & 0xff;

--- a/RA8876_t41_p/src/RA8876_t41_p.h
+++ b/RA8876_t41_p/src/RA8876_t41_p.h
@@ -92,7 +92,7 @@
 
 
 
-#define BUS_WIDTH 8 /*Available options are 8 or 16 */
+//#define BUS_WIDTH 8 /*Available options are 8 or 16 */
 #define SHIFTNUM 8  // number of shifters used (up to 8)
 #define BYTES_PER_BEAT (sizeof(uint8_t))
 #define BEATS_PER_SHIFTER (sizeof(uint32_t) / BYTES_PER_BEAT)
@@ -108,6 +108,22 @@ class RA8876_t41_p : public RA8876_common {
 
     /* Initialize RA8876 */
     boolean begin(uint8_t baud_div);
+
+    // If used this must be called before begin
+    // Set the FlexIO pins.  The first version you can specify just the wr, and read and optionsl first Data.
+    // it will use information in the Flexio library to fill in d1-d7
+    bool setFlexIOPins(uint8_t write_pin, uint8_t rd_pin, uint8_t tft_d0 = 0xff);
+
+    // Set the FlexIO pins.  Specify all of the pins for 8 (or 16) bit mode. Must be called before begin
+    bool setFlexIOPins(uint8_t write_pin, uint8_t rd_pin, 
+                      uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+                      uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7,
+                      uint8_t d8=0xff, uint8_t d9=0xff, uint8_t d10=0xff, uint8_t d11=0xff,
+                      uint8_t d12=0xff, uint8_t d13=0xff, uint8_t d14=0xff, uint8_t d15=0xff
+                      );
+
+
+
 
     /*access*/
     void lcdRegWrite(ru8 reg, bool finalize = true);
@@ -209,7 +225,7 @@ class RA8876_t41_p : public RA8876_common {
     int _rst;
 
     // The Teensy IO pins used for data and Read and Write 
-    uint8_t _data_pins[16], _bus_width, _wr_pin, _rd_pin;  
+    uint8_t _data_pins[16], _wr_pin, _rd_pin;  
 
     uint8_t _flexio_D0, _flexio_WR, _flexio_RD; // which flexio pins do they map to
 

--- a/Ra8876_t3/src/RA8876_t3.cpp
+++ b/Ra8876_t3/src/RA8876_t3.cpp
@@ -65,7 +65,7 @@ RA8876_t3::RA8876_t3(const uint8_t CSp, const uint8_t RSTp, const uint8_t mosi_p
     _sclk = sclk_pin;
     _cs = CSp;
     _rst = RSTp;
-    RA8876_GFX(BUS_WIDTH);
+    RA8876_GFX(8);  // Assumes 8 bit 
 }
 
 //**************************************************************//

--- a/Ra8876_t3/src/RA8876_t3.h
+++ b/Ra8876_t3/src/RA8876_t3.h
@@ -82,7 +82,6 @@
 // Default to a relatively slow speed for breadboard testing.
 // const ru32 SPIspeed = 47000000;
 const ru32 SPIspeed = 3000000;
-//#define BUS_WIDTH 8
 
 class RA8876_t3 : public RA8876_common {
   public:

--- a/Ra8876_t3/src/RA8876_t3.h
+++ b/Ra8876_t3/src/RA8876_t3.h
@@ -88,7 +88,8 @@ class RA8876_t3 : public RA8876_common {
     RA8876_t3(const uint8_t CSp = 10, const uint8_t RSTp = 8, const uint8_t mosi_pin = 11, const uint8_t sclk_pin = 13, const uint8_t miso_pin = 12);
 
     volatile bool activeDMA = false; // Unfortunately must be public so asyncEventResponder() can set it
-
+    bool DMAFinished() {return !activeDMA;}
+    
     boolean begin(uint32_t spi_clock = SPIspeed);
 
     /*access*/


### PR DESCRIPTION
It was getting confusing.  Some places have/had BUS_WIDTH as a define, plus the main class has it as a member variable.
So member variable is now _bus_width.   SPI is by default set to 8.  FlexIO if BUS_WIDTH is not set defaults to 8.
Can update by method.

Added functions to allow you to set the FlexIO pins to be used.  Two versions of the API:
```
    // If used this must be called before begin
    // Set the FlexIO pins.  The first version you can specify just the wr, and read and optionsl first Data.
    // it will use information in the Flexio library to fill in d1-d7
    bool setFlexIOPins(uint8_t write_pin, uint8_t rd_pin, uint8_t tft_d0 = 0xff);

    // Set the FlexIO pins.  Specify all of the pins for 8 (or 16) bit mode. Must be called before begin
    bool setFlexIOPins(uint8_t write_pin, uint8_t rd_pin, 
                      uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
                      uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7,
                      uint8_t d8=0xff, uint8_t d9=0xff, uint8_t d10=0xff, uint8_t d11=0xff,
                      uint8_t d12=0xff, uint8_t d13=0xff, uint8_t d14=0xff, uint8_t d15=0xff
                      );

```
The first one, if you have updated flexio library, there is methods of tell me what IO pin corresponds to this FLEXIO pin... 
So figures out from WR, RD, D0, which flexio object you are using, and then tries to fill in the next 7 or 15 depending on _bus_width.

The second one allows you to blindly set it.  Note: the flexio begin method will validate the pins.

Added back a DMAFinished method that was in before.

Played around a little with readPixel stuff.  Currently still using digitalWriteFast to control RD pin, but unclear how much this helps, other than maybe gives the display a slightly longer time after it goes low for it to update the signals. 

@mjs513 and I have been playing with the read code and so far there is any implementation that appears to work consistently.  Will play more later (maybe)
